### PR TITLE
Change UTF8 to utf8mb4 for MySQL example

### DIFF
--- a/app/config/database.php
+++ b/app/config/database.php
@@ -39,7 +39,7 @@ return
 			'reconnect'   => false,
 			'queries'     =>
 			[
-				'SET NAMES UTF8',
+				'SET NAMES utf8mb4',
 			],
 		],
 


### PR DESCRIPTION
Due to bug in MySQL/MariaDB, utf8mb4 needs to be used for proper UTF-8 encoding.